### PR TITLE
Show the team with max chance to reach currently selected round

### DIFF
--- a/bracket.js
+++ b/bracket.js
@@ -263,8 +263,9 @@ function main(teams) {
     }
     var reachableTeams = _.flatten(reachTeams(game));
 
+    var round = game.round == 7 ? 6 : game.round;
     return _.max(reachableTeams, function(t) {
-      return t.team["round" + game.round];
+      return t.team["round" + round];
     });
   }
 

--- a/bracket.js
+++ b/bracket.js
@@ -263,8 +263,8 @@ function main(teams) {
     }
     var reachableTeams = _.flatten(reachTeams(game));
 
-    return _.max(reachableTeams, function(game) {
-      return game.team["round" + game.round]
+    return _.max(reachableTeams, function(t) {
+      return t.team["round" + game.round];
     });
   }
 


### PR DESCRIPTION
There was a bug in my previous pull request (https://github.com/llimllib/roundbracket/pull/2). Variable shadowing fail. Oops.

Notice that Wisconsin is erroneously highlighted. (I'm hovering over the center here.)

![screen shot 2015-03-20 at 1 31 01 pm](https://cloud.githubusercontent.com/assets/5513/6758366/9a7e6ff8-cf05-11e4-8109-763f3c9f3df3.png)

Now.

![screen shot 2015-03-20 at 1 31 19 pm](https://cloud.githubusercontent.com/assets/5513/6758379/b041797a-cf05-11e4-96d4-067cb252328c.png)
